### PR TITLE
Os Independency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Check out the [streamlit app](https://gen-atomic.streamlit.app/) to get an idea 
    .\setup.sh
    ```
 
+3. Download [Ollama](https://ollama.com/download) 
+
 ## Run the Code
 
 1. Run main method of the file 'ExperimentHost.py'. You will see the default experiment/benchmark scores like the following:

--- a/src/providers/OllamaModelProvider.py
+++ b/src/providers/OllamaModelProvider.py
@@ -50,18 +50,14 @@ class OllamaModelProvider(ModelProviderBase, ModelBase):
         :return:
         """
         modelName = self.ModelConfiguration
-        process = subprocess.Popen(["wsl", "--user", "root", "--", "ollama run", modelName], stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+        process = subprocess.Popen(["ollama run", modelName], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         process.communicate()
         return process
 
     def Generate(self, description: str) -> str:
 
-
         modelName = self.ModelConfiguration
-        ollama_server_process = self.start_ollama_server()
-
-        #time.sleep(2)  # Adjust delay as needed
+        #ollama_server_process = self.start_ollama_server()
 
         client = ollama.Client('http://localhost:11434')  # Specify full URL with port
         instruction:str = "Consider yourself a function that takes the input of asked validation regex statement, and your output is '''Regex: {created regex}''' Do not give me an explanation, only give me a regex expression. Do not add any additional characters."
@@ -72,7 +68,7 @@ class OllamaModelProvider(ModelProviderBase, ModelBase):
         response = client.generate(model=modelName, prompt=prompt)        #phi3,llama2,llama3,deepseek-coder,codegemma,starcoder2  ref:https://ollama.com/library?sort=popular
         answer = response['response']
 
-        ollama_server_process.terminate()       #TODO: Manage the connecion. Do not terminate on every call.
+        #ollama_server_process.terminate()       #TODO: Manage the connecion. Do not terminate on every call.
 
         gencode:str = str(answer).strip().replace("Regex: ","").replace("```","").replace("`","")      #TODO: Output parsers here please!
         print(f"A: {Fore.CYAN}{gencode}{Fore.RESET}")

--- a/src/utility/Paths.py
+++ b/src/utility/Paths.py
@@ -1,3 +1,4 @@
+
 import os
 from pathlib import Path
 from unittest import TestCase
@@ -29,16 +30,16 @@ class Paths(object):
     def _FindProjectRoot(self, path: str) -> str:
         srcRoot: str = ""
 
-        if (path.__contains__("\\src\\")):  # We assume that no subfolders with the name 'src' will be added to the project.
+        if ("src" in path.split(os.path.sep)):  # Using os.path.sep for platform independence
             cursor = path
             isSrc: bool = False
-            while (isSrc == False):
+            while (not isSrc):
                 cursor = Path(cursor).parent
                 part = cursor.parts[-1]
                 if (part == "src"):
                     isSrc = True
                     srcRoot = str(cursor)
-        elif (path.__contains__("\\src")):
+        elif ("src" in path):
             srcRoot = path
         else:
             if (self._IsFolderExists(path, "src")):
@@ -53,30 +54,33 @@ class Paths(object):
 class PathsTest(TestCase):
 
     def test_FindProjectRoot_NestedSrcPath_ReturnParent(self):
-        self.assertEqual(r"C:\Projects\gen-atomic",
-                         Paths()._FindProjectRoot(r"C:\Projects\gen-atomic\src\UI\folder\StreamlitUI.py"))
+        self.assertEqual(os.path.join("C:", "Projects", "gen-atomic"),
+                         Paths()._FindProjectRoot(
+                             os.path.join("C:", "Projects", "gen-atomic", "src", "UI", "folder", "StreamlitUI.py")))
 
     def test_FindProjectRoot_SrcFilePath_ReturnParent(self):
-        self.assertEqual(r"C:\Projects\gen-atomic",
-                         Paths()._FindProjectRoot(r"C:\Projects\gen-atomic\src\StreamlitUI.py"))
+        self.assertEqual(os.path.join("C:", "Projects", "gen-atomic"),
+                         Paths()._FindProjectRoot(
+                             os.path.join("C:", "Projects", "gen-atomic", "src", "StreamlitUI.py")))
 
     def test_FindProjectRoot_SrcFolderPath_ReturnParent(self):
-        self.assertEqual(str(Path(r"C:\Projects\gen-atomic")), Paths()._FindProjectRoot(r"C:\Projects\gen-atomic\src"))
+        self.assertEqual(os.path.join("C:", "Projects", "gen-atomic"),
+                         Paths()._FindProjectRoot(os.path.join("C:", "Projects", "gen-atomic", "src")))
 
     def test_FindProjectRoot_ProjectFolderPath_ReturnParent(self):
         paths = Paths()
         from unittest.mock import patch
         with patch.object(paths, '_IsFolderExists', return_value=True):
-            self.assertEqual(r"C:\Projects\gen-atomic", paths._FindProjectRoot(r"C:\Projects\gen-atomic"))
+            self.assertEqual(os.path.join("C:", "Projects", "gen-atomic"),
+                             paths._FindProjectRoot(os.path.join("C:", "Projects", "gen-atomic")))
 
     def test_FindProjectRoot_NoProjectPath_RaiseError(self):
         paths = Paths()
         from unittest.mock import patch
         with patch.object(paths, '_IsFolderExists', return_value=False):
             with self.assertRaises(Exception):
-                paths._FindProjectRoot(r"C:\Projects\somerandomfolder")
+                paths._FindProjectRoot(os.path.join("C:", "Projects", "somerandomfolder"))
 
 
 if __name__ == "__main__":
     print("root: ", Paths().GetProjectRoot())
-


### PR DESCRIPTION
- Paths are now OS agnostic.
- Commands updated and became OS agnostic: no need to use WSL commands to start Ollama server (after Windows support has been added).
- README.md update: Ollama download link added to installation guideline. 