### PR TITLE
Fix emotion decorator docstring typo

### DIFF
--- a/src/prompting/decorators/impl/emotion_decorator.py
+++ b/src/prompting/decorators/impl/emotion_decorator.py
@@ -4,7 +4,7 @@ from prompting.decorators.prompt_decorator_base import PromptDecoratorBase
 
 class EmotionDecorator(PromptDecoratorBase):
     """
-    Decorator imlementation for emotion prompting.
+    Decorator implementation for emotion prompting.
     """
 
     _EMOTION_PROMPT_AS_PREFIX: Prompt = Prompt(


### PR DESCRIPTION
## Summary
- correct spelling mistake in emotion decorator docstring

## Testing
- `pytest -q` *(fails: RuntimeError no validator found and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_685adcbac8b0832ba0fb8eb0cf5fc54b