### PR TITLE
Fix project root detection for Paths utility

### DIFF
--- a/src/utility/Paths.py
+++ b/src/utility/Paths.py
@@ -41,7 +41,7 @@ class Paths(object):
                 if part == "src":
                     isSrc = True
                     srcRoot = str(cursor)
-        elif path.__contains__(os.path.sep + "src"):
+        elif path.endswith(os.path.sep + "src"):
             srcRoot = path
         else:
             if self._IsFolderExists(path, "src"):


### PR DESCRIPTION
## Summary
- ensure `_FindProjectRoot` only matches paths that end with `src`
- update tests run successfully

## Testing
- `pip install -q -r src/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c09f2a64832b977c7b8073967c92