### PR TITLE
Add Streamlit page for regex units

### DIFF
--- a/src/pages/AtomicRegexUnits.py
+++ b/src/pages/AtomicRegexUnits.py
@@ -1,0 +1,26 @@
+import pandas as pd
+import streamlit as st
+from st_aggrid import AgGrid, GridOptionsBuilder
+
+from data.DatasetXmlRepository import DatasetXmlRepository
+from utility.Paths import Paths
+
+st.title("Atomic Regex Units")
+
+# Load dataset
+path = Paths().GetDataset("AtomicRegexValDataset")
+
+ds = DatasetXmlRepository.Load(path)
+
+# Convert units to DataFrame
+records = [{"Name": u.Name, "Description": u.Description, "UnitType": u.UnitType} for u in ds.Units]
+
+df = pd.DataFrame(records)
+
+# Configure AgGrid
+builder = GridOptionsBuilder.from_dataframe(df)
+builder.configure_default_column(editable=True, resizable=True, filter=True)
+options = builder.build()
+
+AgGrid(df, gridOptions=options, allow_unsafe_jscode=True, editable=True)
+

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -12,3 +12,4 @@ antlr4-python3-runtime
 pydantic
 fastapi
 uvicorn
+streamlit-aggrid


### PR DESCRIPTION
## Summary
- display regex units with streamlit-aggrid
- add dependency for streamlit-aggrid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6bacb910832bbeb710245d98b563